### PR TITLE
Fixing nested using_connection blocks

### DIFF
--- a/lib/active_record/connections.rb
+++ b/lib/active_record/connections.rb
@@ -26,27 +26,12 @@ module ActiveRecord
     #   end
     #
     def using_connection(connection_name, connection_spec)
+      old_proxy_connection = proxy_connection
       self.proxy_connection = ConnectionProxy.new(connection_name, connection_spec)
-
-      def self.connection_pool
-        connection_handler.retrieve_connection_pool(proxy_connection)
-      end
-
-      def self.retrieve_connection
-        connection_handler.retrieve_connection(proxy_connection)
-      end
 
       yield
     ensure
-      self.proxy_connection = nil
-
-      def self.connection_pool
-        connection_handler.retrieve_connection_pool(self)
-      end
-
-      def self.retrieve_connection
-        connection_handler.retrieve_connection(self)
-      end
+      self.proxy_connection = old_proxy_connection
     end
 
     def proxy_connection
@@ -61,4 +46,12 @@ end
 
 ActiveSupport.on_load(:active_record) do
   extend ActiveRecord::Connections
+
+  def self.connection_pool
+    connection_handler.retrieve_connection_pool(proxy_connection || self)
+  end
+
+  def self.retrieve_connection
+    connection_handler.retrieve_connection(proxy_connection || self)
+  end
 end

--- a/spec/active_record/connections_spec.rb
+++ b/spec/active_record/connections_spec.rb
@@ -69,6 +69,24 @@ describe ActiveRecord::Connections do
     end
   end
 
+  it 'allows nested proxy connections' do
+    @customer_1.using_connection do
+      @customer_2.using_connection do
+        @customer_3.using_connection do
+          Contact.update_all(:name => @customer_3.name)
+        end
+
+        Contact.update_all(:name => @customer_2.name)
+      end
+
+      Contact.update_all(:name => @customer_1.name)
+    end
+
+    Customer.each do |customer|
+      Contact.first.name.should eq customer.name
+    end
+  end
+
   it 'do not propagate proxy connection between threads (thread-safe)' do
     Thread.new do
       ActiveRecord::Base.proxy_connection = 'proxy connection from another thread'


### PR DESCRIPTION
I went ahead and added the ability to use nested using_connection blocks, along with changing the ActiveRecord::Base method overrides.
