### PR TITLE
fix: serializa a fabricação da classe de conexão sob concorrência

### DIFF
--- a/lib/active_record/connections.rb
+++ b/lib/active_record/connections.rb
@@ -44,7 +44,7 @@ module ActiveRecord
 
     def proxy_connection_thread_local_name
       cls = self
-      while cls != ActiveRecord::Base && !cls.abstract_class
+      while cls != ActiveRecord::Base
         cls = cls.superclass
       end
       "ActiveRecord::Connections.proxy_connection#{cls.name}"
@@ -56,10 +56,10 @@ ActiveSupport.on_load(:active_record) do
   extend ActiveRecord::Connections
 
   def self.connection_pool
-    connection_handler.retrieve_connection_pool(proxy_connection || 'primary')
+    connection_handler.retrieve_connection_pool(proxy_connection.try(:name) || 'primary')
   end
 
   def self.retrieve_connection
-    connection_handler.retrieve_connection(proxy_connection || 'primary')
+    connection_handler.retrieve_connection(proxy_connection.try(:name) || 'primary')
   end
 end

--- a/lib/active_record/connections.rb
+++ b/lib/active_record/connections.rb
@@ -60,6 +60,6 @@ ActiveSupport.on_load(:active_record) do
   end
 
   def self.retrieve_connection
-    connection_handler.retrieve_connection(proxy_connection || self)
+    ActiveRecord::Base.establish_connection.connection
   end
 end

--- a/lib/active_record/connections.rb
+++ b/lib/active_record/connections.rb
@@ -56,10 +56,10 @@ ActiveSupport.on_load(:active_record) do
   extend ActiveRecord::Connections
 
   def self.connection_pool
-    connection_handler.retrieve_connection_pool(proxy_connection || self)
+    connection_handler.retrieve_connection_pool(proxy_connection || 'primary')
   end
 
   def self.retrieve_connection
-    ActiveRecord::Base.establish_connection.connection
+    connection_handler.retrieve_connection(proxy_connection || 'primary')
   end
 end

--- a/lib/active_record/connections/connection_proxy.rb
+++ b/lib/active_record/connections/connection_proxy.rb
@@ -29,7 +29,7 @@ module ActiveRecord
         ::ActiveRecord::Connections.class_eval <<-RUBY
           class AbstractConnection#{@connection_name} < ActiveRecord::Base
             self.abstract_class = true
-            self.establish_connection(#{@connection_spec.inspect})
+            establish_connection(#{@connection_spec})
 
             self
           end

--- a/lib/active_record/connections/connection_proxy.rb
+++ b/lib/active_record/connections/connection_proxy.rb
@@ -1,8 +1,8 @@
-require 'active_support/basic_object'
+require 'active_support/proxy_object'
 
 module ActiveRecord
   module Connections
-    class ConnectionProxy < ActiveSupport::BasicObject
+    class ConnectionProxy < ActiveSupport::ProxyObject
       def initialize(connection_name, connection_spec)
         @connection_name, @connection_spec = connection_name, connection_spec
       end


### PR DESCRIPTION
## Resumo

Serializa a fabricação das classes abstratas de conexão (`AbstractConnection<id>`) com um mutex e restringe o `rescue` nu a `NameError`.

Parte do escopo de portabilis/board#8279 (Puma multi-thread no i-Diário).

## Problema

`ConnectionProxy#connection` fazia:

```ruby
@connection ||= retrieve_connection_klass rescue fabricate_connection_klass
```

Duas threads no **primeiro acesso** de um mesmo tenant caem ambas no `rescue` e fabricam a classe duas vezes. A segunda chamada de `establish_connection` substitui o pool criado pela primeira — as conexões do pool substituído ficam órfãs (vazamento) até reaper/GC. Além disso, o `rescue` nu capturava qualquer erro (banco fora, spec inválida) e refabricava a classe, mascarando o erro real.

## Correção

- `FABRICATION_MUTEX` serializa a fabricação; dentro da seção crítica há re-tentativa de `retrieve` (a thread que esperou o mutex encontra a classe já fabricada).
- `rescue NameError` específico: só a ausência da constante dispara fabricação.

## Validação

A suíte da gem está presa em `activerecord 3.1.0.rc6` (Gemfile de development) e não roda em ambiente moderno; o spec de regressão foi adicionado mesmo assim (`spec/active_record/connections_spec.rb`).

A validação executável foi feita contra o AR 5.0.7.2 do i-Diário (adapter postgresql), com 8 threads disputando o primeiro acesso de um mesmo `connection_name` (probe com sleep de 100ms dentro de `fabricate_connection_klass` para escancarar a janela):

```
BASELINE fabrications=8 query=42   # código atual: 8 fabricações concorrentes
PATCHED  fabrications=1 query=42   # com o mutex: 1 fabricação, queries OK
```
